### PR TITLE
add missing conda channel

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get install -y git wget build-essential unzip
 RUN apt-get clean
 
 
-RUN conda config --add channels bioconda
+RUN conda config --add channels bioconda bpeng
 RUN conda install --yes biopython=1.70
 RUN conda install --yes statsmodels pysam plink gffutils genepop trimal
 RUN conda install --yes  simuPOP


### PR DESCRIPTION
It seems to me that this channel needs to be added or simupop can't be installed.

https://anaconda.org/search?q=simupop