### PR TITLE
Include --allow-root in CMD

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,4 +42,4 @@ RUN git clone https://github.com/PacktPublishing/Bioinformatics-with-Python-Cook
 WORKDIR /PacktPublising/notebooks
 
 RUN echo setterm -foreground magenta >> /etc/bash.bashrc
-CMD jupyter-notebook --ip=0.0.0.0 --no-browser --port=9875
+CMD jupyter-notebook --ip=0.0.0.0 --no-browser --allow-root --port=9875


### PR DESCRIPTION
Without --allow-root, docker can't launch jupyter-notebook and the container stops running.
I run this docker build command:
`docker build -t bio https://raw.githubusercontent.com/PacktPublishing/Bioinformatics-with-Python-Cookbook-Second-Edition/master/docker/Dockerfile`
on a MacOS:
```
$ uname -a
Darwin <ommited>.local 18.6.0 Darwin Kernel Version 18.6.0: Thu Apr 25 23:16:27 PDT 2019; root:xnu-4903.261.4~2/RELEASE_X86_64 x86_64
```